### PR TITLE
PHP 7.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 php:
-  - 5.3
-  - 5.4
-  - 5.5
+  - 5.6
+  - 7.0
   - hhvm
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "twig/twig": "~1",
-        "phpunit/phpunit": "~4",
+        "phpunit/phpunit": "~5.5",
         "symfony/console": "~2"
     },
     "suggest": {

--- a/src/Naneau/FileGen/File.php
+++ b/src/Naneau/FileGen/File.php
@@ -14,7 +14,7 @@ use Naneau\FileGen\Parameterized;
 use Naneau\FileGen\AccessRights;
 
 use Naneau\FileGen\File\Contents as ContentGenerator;
-use Naneau\FileGen\File\Contents\String as StringContents;
+use Naneau\FileGen\File\Contents\StringBased as StringContents;
 
 use \InvalidArgumentException;
 

--- a/src/Naneau/FileGen/File/Contents/StringBased.php
+++ b/src/Naneau/FileGen/File/Contents/StringBased.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * String.php
+ * StringBased.php
  *
  * @category        Naneau
  * @package         FileGen
@@ -12,7 +12,7 @@ namespace Naneau\FileGen\File\Contents;
 use Naneau\FileGen\File\Contents;
 
 /**
- * String
+ * StringBased
  *
  * String based file contents
  *
@@ -20,7 +20,7 @@ use Naneau\FileGen\File\Contents;
  * @package         FileGen
  * @subpackage      File
  */
-class String implements Contents
+class StringBased implements Contents
 {
     /**
      * Contents of the file
@@ -54,7 +54,7 @@ class String implements Contents
      * Set the contents of the file
      *
      * @param  ContentGenerator|string $contents
-     * @return String
+     * @return self
      */
     public function setContents($contents)
     {


### PR DESCRIPTION
This PR adds support for PHP 7.0:
* Rename `Naneau\FileGen\File\Contents\String` to 'StringBased' as 'String' is now a reserved keyword in PHP 7 ([source](http://php.net/manual/en/reserved.other-reserved-words.php)).
* Update PHPUnit to be compatible with PHP 7.0.